### PR TITLE
Add a workflow to run evals automatically

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,74 @@
+name: Eval Tests
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Fetch Google credentials
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_GEMINI_KEY }}'
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      # The examples database shouldn't change super often.
+      # Cache it between runs so that we don't have to re-compute any embeddings
+      # that we already computed previously.
+      # Key the cache on the hash of the examples database so that
+      # we always regenerate embeddings from scratch on any change --
+      # this is probably unnecessary because the embedding tool knows how to
+      # diff the database against the existing embeddings, and it may become
+      # expensive if the examples database becomes large, but it's a
+      # conservative approach for now while the DB is small.
+      - name: Cache previous examples files
+        uses: actions/cache@v4
+        with:
+          path: |
+            code_examples_embedded.json
+            concept_examples_embedded.json
+          key: examples-embedded-${{ hashFiles('*_examples.json') }}
+      - name:  Generate example files if needed
+        run: python embed_examples.py
+
+      - name: Run benchmark
+        run: python eval/accuracy_evaluator.py --github-benchmark-data-file=output.json
+
+      - name: Evaluate and store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'customBiggerIsBetter'
+          # Where the output from the benchmark tool is stored
+          output-file-path: output.json
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable alert commit comment
+          comment-on-alert: true
+          # Enable Job Summary for PRs
+          summary-always: true
+          # How much run-to-run change is needed to trigger an alert
+          alert-threshold: "200%"
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          auto-push: true

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -52,9 +52,13 @@ crash.*.log
 # Language Specific
 # ...
 
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json
+
 # Generated files
 code_examples_embedded.json
 **/__pycache__/*
 app-migration-diff.json
 concept_examples_embedded.json
 gemini_migration.log
+output.json

--- a/eval/accuracy_evaluator.py
+++ b/eval/accuracy_evaluator.py
@@ -58,7 +58,7 @@ class CodeDescriptionEvaluator:
     def get_code_embedding(self, code_snippet):
         """Generate embeddings for code snippets."""
         inputs = self.code_tokenizer(
-            code_snippet, return_tensors="pt", truncation=True, padding=True
+            code_snippet, return_tensors="pt", truncation=True, max_length=64, padding=True
         )
         with torch.no_grad():
             outputs = self.code_model(**inputs)
@@ -68,7 +68,7 @@ class CodeDescriptionEvaluator:
     def get_desc_embedding(self, description):
         """Generate embeddings for descriptions."""
         inputs = self.desc_tokenizer(
-            description, return_tensors="pt", truncation=True, padding=True
+            description, return_tensors="pt", truncation=True, max_length=64, padding=True
         )
         with torch.no_grad():
             outputs = self.desc_model(**inputs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ langchain_google_genai
 dataclasses
 typing
 tree_sitter<0.23
-tree_sitter_java
+tree_sitter_java<0.23
 networkx
 ipykernel
 matplotlib


### PR DESCRIPTION
(Re-creating this PR to target `main`, previously it was stacked on a different branch.)

Automatically run evals every time commits are pushed to `main`.  Also enable manually triggering evals via the "Actions" panel in the GitHub UI.

Automatically post a commit comment if performance gets significantly worse.  "Significantly" is defined by default to be 2x (200%).  We will probably want to tune this over time to be more stringent, by setting the `alert-threshold` value on the "Store benchmark result" task in the new workflow, to some value other than its default of `"200%"`.

Automatically publish eval results to the `gh-pages` branch in this repository.  (The results are not visible on GitHub Pages because this is a private repository, but at least users can check out the branch and open the results page in a browser.)